### PR TITLE
Deprecates OnPlayerPrivmsg and OnPlayerTeamPrivmsg

### DIFF
--- a/scripting/callbacks/OnPlayerPrivmsg.md
+++ b/scripting/callbacks/OnPlayerPrivmsg.md
@@ -8,6 +8,12 @@ tags: ["player"]
 
 <TagLinks />
 
+::: warning
+
+This callback was removed in SA-MP 0.3. See below how to create a /pm command.
+
+:::
+
 ## Description
 
 This callback is called when a player sends a private message through the native PM system /pm.

--- a/scripting/callbacks/OnPlayerTeamPrivmsg.md
+++ b/scripting/callbacks/OnPlayerTeamPrivmsg.md
@@ -8,6 +8,12 @@ tags: ["player"]
 
 <TagLinks />
 
+::: warning
+
+This function was removed in SA-MP 0.3. You must make your own command using OnPlayerCommandText.
+
+:::
+
 ## Description
 
 This callback is called when a player sends a team private message through the native TPM system (/tpm).
@@ -67,3 +73,4 @@ Player teams must be set with SetPlayerTeam. If not, messages will be sent to al
 :::
 
 ## Related Functions
+


### PR DESCRIPTION
Noticed they are deprecated on the SA:MP forums but not on the open.mp wiki. If they're not supposed to be deprecated then ignore this PR.