### PR TITLE
Remove sa-mp wiki for now

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,10 +90,6 @@ module.exports = {
               href: "https://sa-mp.com",
             },
             {
-              label: "SA-MP Wiki",
-              href: "https://wiki.sa-mp.com",
-            },
-            {
               label: "Blog",
               to: "blog",
               href: "https://open.mp/blog",


### PR DESCRIPTION
If it comes back, we can always restore, but until then, it's a dead link in the footer.