### PR TITLE
Add CLA info to contribution guide

### DIFF
--- a/docs/meta/Contributing.md
+++ b/docs/meta/Contributing.md
@@ -211,3 +211,7 @@ And copy only the `<table>` element in:
 The conversion likely won't be perfect. So you'll have to do a bit of manual cleanup. The formatting extensions listed above should help with that but you may still need to just spend some time doing manual work.
 
 If you don't have time, don't worry! Submit an unfinished draft and someone else can pick up where you left off!
+
+## License Agreement
+
+All open.mp projects have a [Contributor License Agreement][https://cla-assistant.io/openmultiplayer/homepage]. This basically just means you agree to let us use your work, and put it under an open-source license. When you open a Pull Request for the first time, the CLA-Assistant bot will post a link where you can sign the agreement.


### PR DESCRIPTION
Just taken from https://github.com/openmultiplayer/homepage/blob/master/CONTRIBUTING.md but worth including if we're going back to basics in this doc.