### PR TITLE
Sidebar ordering

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1,24 +1,24 @@
 const fs = require("fs");
-const path = require('path');
+const path = require("path");
 
-const SIDE_BAR_NAME = 'Sidebar';
+const SIDE_BAR_NAME = "Sidebar";
 const CATEGORY_NAME_CAPITALIZATION = true;
 
 function parseDir(filename) {
   const stats = fs.lstatSync(filename);
-  const info = {}
+  const info = {};
 
   // check if it's a directory
   if (stats.isDirectory()) {
     // if it's `docs` directory, set it as main and first key
-    if (path.basename(filename) === 'docs') {
+    if (path.basename(filename) === "docs") {
       info[SIDE_BAR_NAME] = fs.readdirSync(filename).map(function (child) {
-        return parseDir(filename + '/' + child);
+        return parseDir(filename + "/" + child);
       });
     }
     // it's a directory inside `docs` folder
     else {
-      info.type = 'category';
+      info.type = "category";
       const catName = path.basename(filename);
 
       if (CATEGORY_NAME_CAPITALIZATION) {
@@ -28,24 +28,33 @@ function parseDir(filename) {
       }
 
       // sort files and directories alphabetical and files first
-      const sortedFilesAndDirs = fs.readdirSync(filename, "utf8").map(child => {
-        const path = filename + '/' + child;
-        return {
-          name: child,
-          isDir: fs.lstatSync(path).isDirectory()
-        };
-      }).sort((a, b) => b.isDir - a.isDir || a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1);
+      const sortedFilesAndDirs = fs
+        .readdirSync(filename, "utf8")
+        .map((child) => {
+          const path = filename + "/" + child;
+          return {
+            name: child,
+            isDir: fs.lstatSync(path).isDirectory(),
+          };
+        })
+        .sort((a, b) =>
+          b.isDir - a.isDir || a.name.toLowerCase() > b.name.toLowerCase()
+            ? 1
+            : -1
+        );
 
       info.items = sortedFilesAndDirs.map(function (item) {
-        return parseDir(filename + '/' + item.name);
+        return parseDir(filename + "/" + item.name);
       });
 
       // ignore `index.md` and `README.md` files in directories placed in `docs`
       let index = info.items.length;
       while (index--) {
         if (
-          (typeof info.items[index] === 'string' && info.items[index].includes('index')) ||
-          (typeof info.items[index] === 'string' && info.items[index].includes('README'))
+          (typeof info.items[index] === "string" &&
+            info.items[index].includes("index")) ||
+          (typeof info.items[index] === "string" &&
+            info.items[index].includes("README"))
         ) {
           info.items.splice(index, 1);
         }
@@ -58,11 +67,11 @@ function parseDir(filename) {
     const tmpPath = filename.split("/");
     tmpPath.pop();
     tmpPath.splice(0, 1);
-    let docPath = '';
-    tmpPath.map((name) => docPath = docPath + name + '/');
-    return docPath + path.basename(filename).replace('.md', '');
+    let docPath = "";
+    tmpPath.map((name) => (docPath = docPath + name + "/"));
+    return docPath + path.basename(filename).replace(".md", "");
   }
   return info;
 }
 
-module.exports = parseDir('docs');
+module.exports = parseDir("docs");

--- a/sidebars.js
+++ b/sidebars.js
@@ -34,16 +34,19 @@ function parseDir(filename) {
           name: child,
           isDir: fs.lstatSync(path).isDirectory()
         };
-      }).sort((a, b) => b.isDir - a.isDir || a.name > b.name ? 1 : -1);
+      }).sort((a, b) => b.isDir - a.isDir || a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1);
 
       info.items = sortedFilesAndDirs.map(function (item) {
         return parseDir(filename + '/' + item.name);
       });
 
-      // ignore `index.md` files in directories placed in `docs` 
+      // ignore `index.md` and `README.md` files in directories placed in `docs`
       let index = info.items.length;
       while (index--) {
-        if (typeof info.items[index] === 'string' && info.items[index].includes('index')) {
+        if (
+          (typeof info.items[index] === 'string' && info.items[index].includes('index')) ||
+          (typeof info.items[index] === 'string' && info.items[index].includes('README'))
+        ) {
           info.items.splice(index, 1);
         }
       }


### PR DESCRIPTION
Compares lower-cased strings when sorting alphabetically, this then means we can have our `_tutorials` file at the top (as `Tutorials`).

Originally just made `AdvancedStructures.md` and `Binary.md` lowercase like the rest of the files, but figured this is a bit more futureproof.

Also stops `README.md` from displaying under meta, as this is kinda meta-meta info.

Lots of prettier changes here due to the fact this file hasn't been touched in months, my changes are here: 003ba85