### PR TITLE
Remove .md extensions and unnecessary relative paths

### DIFF
--- a/docs/scripting/resources/_server/controllingaserver.md
+++ b/docs/scripting/resources/_server/controllingaserver.md
@@ -22,7 +22,7 @@ The same as running a custom gamemode, except:
 
 ## Passwording your server
 
-- If you want to add a password so only your friends can join, add this to [server.cfg](../_server/server.cfg.md):
+- If you want to add a password so only your friends can join, add this to [server.cfg](server.cfg):
 
 ```
 password whatever
@@ -36,9 +36,9 @@ password whatever
 
 ### Logging In
 
-You can log in either while ingame by typing `/rcon login password` or out of game by using the RCON mode in the [Remote Console](../_server/remoteconsole.md).
+You can log in either while ingame by typing `/rcon login password` or out of game by using the RCON mode in the [Remote Console](remoteconsole).
 
-The password is the same as what you set it as in [server.cfg](../_server/server.cfg.md)
+The password is the same as what you set it as in [server.cfg](server.cfg)
 
 ### Adding Bans
 
@@ -49,7 +49,7 @@ samp.ban is the file used for storing bans, including the following information 
 - IP
 - Date
 - Time
-- Name (Name of person or a reason, see [BanEx](../../functions/BanEx.md))
+- Name (Name of person or a reason, see [BanEx](../../functions/BanEx))
 - Type of ban
 
 To add a ban, simply add a line like so:
@@ -62,7 +62,7 @@ Where `IP_HERE` is, is where you put the IP you would like to ban.
 
 ##### Ban() function
 
-The [Ban](../../functions/Ban.md) function can be used to ban a player from a script. The [BanEx](../../functions/BanEx.md) function will add an optional reason like so:
+The [Ban](../../functions/Ban) function can be used to ban a player from a script. The [BanEx](../../functions/BanEx) function will add an optional reason like so:
 
 ```
 13.37.13.37 [28/05/09 | 13:37:00] Cheater - INGAME BAN
@@ -110,7 +110,7 @@ samp.ban can be found in your sa-mp server directory, it contains lines with the
 - IP
 - Date
 - Time
-- Name (Name of person or a reason (see [BanEx](../../functions/BanEx.md)))
+- Name (Name of person or a reason (see [BanEx](../../functions/BanEx)))
 - Type of ban (INGAME, IP BAN etc,)
 
 Examples:
@@ -165,7 +165,7 @@ These are the functions that you as admin can use:
 | `/rcon kick [ID]`                 | Kick the player with the given ID (_example: /rcon kick 2_).                                                                   |
 | `/rcon ban [ID]`                  | Ban the player with the given ID (_example: /rcon ban 2_).                                                                     |
 | `/rcon changemode [mode]`         | This command will change the current gamemode to the given one (_example: if you want to play sftdm: /rcon changemode sftdm_). |
-| `/rcon gmx`                       | Will load the next gamemode in [server.cfg](../_server/server.cfg).                                                            |
+| `/rcon gmx`                       | Will load the next gamemode in [server.cfg](server.cfg).                                                                       |
 | `/rcon reloadbans`                | reloads the samp.ban where the banned IP addresses are stored. Should be used after unbanning and IP address.                  |
 | `/rcon reloadlog`                 | reloads the server_log.txt. Has no noticeable effect on anything.                                                              |
 | `/rcon say`                       | shows a message to the players in the client-console (example: `/rcon say hello` will show as `Admin: hello`).                 |
@@ -199,10 +199,10 @@ The following callbacks and functions might be useful, as they're related to thi
 
 #### Callbacks
 
-- [OnRconLoginAttempt](../../callbacks/OnRconLoginAttempt.md): Called when an attempt to login to RCON is made.
+- [OnRconLoginAttempt](../../callbacks/OnRconLoginAttempt): Called when an attempt to login to RCON is made.
 
 #### Functions
 
-- [IsPlayerAdmin](../../functions/IsPlayerAdmin.md): Checks if a player is logged into RCON.
+- [IsPlayerAdmin](../../functions/IsPlayerAdmin): Checks if a player is logged into RCON.
 
-- [SendRconCommand](../../functions/SendRconCommand.md): Sends an RCON command via the script.
+- [SendRconCommand](../../functions/SendRconCommand): Sends an RCON command via the script.


### PR DESCRIPTION
Reverts #234 which added `.md` to the end of links in one file and also made the link paths longer than they needed to be.