### PR TITLE
Proper templates for commonly used note blocks

### DIFF
--- a/docs/meta/templates/_version-warning-0.3.7.md
+++ b/docs/meta/templates/_version-warning-0.3.7.md
@@ -1,5 +1,0 @@
-:::warning
-
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::

--- a/docs/scripting/callbacks/OnActorStreamIn.md
+++ b/docs/scripting/callbacks/OnActorStreamIn.md
@@ -7,7 +7,7 @@ tags: []
 
 import T from '../../../src/components/templates.js'
 
-<T.VersionWarn verNum='0.3.7' />
+<T.VersionWarn name='callback' version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnActorStreamIn.md
+++ b/docs/scripting/callbacks/OnActorStreamIn.md
@@ -5,9 +5,9 @@ description: This callback is called when an actor is streamed in by a player's 
 tags: []
 ---
 
-import Warning from '../../meta/templates/\_version-warning-0.3.7.md'
+import T from '../../../src/components/templates.js'
 
-<Warning/>
+<T.VersionWarn verNum='0.3.7' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnActorStreamOut.md
+++ b/docs/scripting/callbacks/OnActorStreamOut.md
@@ -5,11 +5,9 @@ description: This callback is called when an actor is streamed out by a player's
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnActorStreamOut.md
+++ b/docs/scripting/callbacks/OnActorStreamOut.md
@@ -7,7 +7,7 @@ tags: []
 
 :::warning
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
+This callback was added in SA-MP 0.3.7 and will not work in earlier versions!
 
 :::
 

--- a/docs/scripting/callbacks/OnClientMessage.md
+++ b/docs/scripting/callbacks/OnClientMessage.md
@@ -5,11 +5,9 @@ description: This callback gets called whenever the NPC sees a ClientMessage.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This NPC callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='NPC callback' version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnDialogResponse.md
+++ b/docs/scripting/callbacks/OnDialogResponse.md
@@ -5,11 +5,9 @@ description: This callback is called when a player responds to a dialog shown us
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnEnterExitModShop.md
+++ b/docs/scripting/callbacks/OnEnterExitModShop.md
@@ -5,11 +5,9 @@ description: This callback is called when a player enters or exits a mod shop.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnIncomingConnection.md
+++ b/docs/scripting/callbacks/OnIncomingConnection.md
@@ -5,11 +5,9 @@ description: This callback is called when an IP address attempts a connection to
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3z R2-2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3z R2-2' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerClickMap.md
+++ b/docs/scripting/callbacks/OnPlayerClickMap.md
@@ -5,11 +5,9 @@ description: OnPlayerClickMap is called when a player places a target/waypoint o
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3d and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3d' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerClickPlayer.md
+++ b/docs/scripting/callbacks/OnPlayerClickPlayer.md
@@ -5,11 +5,9 @@ description: Called when a player double-clicks on a player on the scoreboard.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerClickPlayerTextDraw.md
+++ b/docs/scripting/callbacks/OnPlayerClickPlayerTextDraw.md
@@ -5,11 +5,9 @@ description: This callback is called when a player clicks on a player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerClickTextDraw.md
+++ b/docs/scripting/callbacks/OnPlayerClickTextDraw.md
@@ -5,11 +5,9 @@ description: This callback is called when a player clicks on a textdraw or cance
 tags: ["player", "textdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerEditAttachedObject.md
+++ b/docs/scripting/callbacks/OnPlayerEditAttachedObject.md
@@ -5,11 +5,9 @@ description: This callback is called when a player ends attached object edition 
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerEditObject.md
+++ b/docs/scripting/callbacks/OnPlayerEditObject.md
@@ -5,11 +5,9 @@ description: This callback is called when a player finishes editing an object (E
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerFinishedDownloading.md
+++ b/docs/scripting/callbacks/OnPlayerFinishedDownloading.md
@@ -5,11 +5,9 @@ description: This callback is called when a player finishes downloading custom m
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3.DL and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3.DL' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerGiveDamage.md
+++ b/docs/scripting/callbacks/OnPlayerGiveDamage.md
@@ -5,11 +5,9 @@ description: This callback is called when a player gives damage to another playe
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3d and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3d' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerGiveDamageActor.md
+++ b/docs/scripting/callbacks/OnPlayerGiveDamageActor.md
@@ -5,11 +5,9 @@ description: This callback is called when a player gives damage to an actor.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerRequestDownload.md
+++ b/docs/scripting/callbacks/OnPlayerRequestDownload.md
@@ -5,11 +5,9 @@ description: This callback is called when a player request for custom model down
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3.DL R1 and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3.DL R1' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerSelectObject.md
+++ b/docs/scripting/callbacks/OnPlayerSelectObject.md
@@ -5,11 +5,9 @@ description: This callback is called when a player selects an object after Selec
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerStreamIn.md
+++ b/docs/scripting/callbacks/OnPlayerStreamIn.md
@@ -5,11 +5,9 @@ description: This callback is called when a player is streamed by some other pla
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerStreamOut.md
+++ b/docs/scripting/callbacks/OnPlayerStreamOut.md
@@ -5,11 +5,9 @@ description: This callback is called when a player is streamed out from some oth
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerTakeDamage.md
+++ b/docs/scripting/callbacks/OnPlayerTakeDamage.md
@@ -5,11 +5,9 @@ description: This callback is called when a player takes damage.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3d and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3d' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnPlayerWeaponShot.md
+++ b/docs/scripting/callbacks/OnPlayerWeaponShot.md
@@ -5,11 +5,9 @@ description: This callback is called when a player fires a shot from a weapon.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnRconLoginAttempt.md
+++ b/docs/scripting/callbacks/OnRconLoginAttempt.md
@@ -5,11 +5,9 @@ description: This callback is called when someone attempts to log in to RCON in-
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnRecordingPlaybackEnd.md
+++ b/docs/scripting/callbacks/OnRecordingPlaybackEnd.md
@@ -5,11 +5,9 @@ description: This callback is called when a recorded file being reproduced with 
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This NPC callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='NPC callback' version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnTrailerUpdate.md
+++ b/docs/scripting/callbacks/OnTrailerUpdate.md
@@ -5,11 +5,9 @@ description: This callback is called when a player sent a trailer update.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3z R4 and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3z R4' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnUnoccupiedVehicleUpdate.md
+++ b/docs/scripting/callbacks/OnUnoccupiedVehicleUpdate.md
@@ -5,11 +5,9 @@ description: This callback is called when a player's client updates/syncs the po
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3c R3 and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3c R3' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnVehicleDamageStatusUpdate.md
+++ b/docs/scripting/callbacks/OnVehicleDamageStatusUpdate.md
@@ -5,11 +5,9 @@ description: This callback is called when a vehicle element such as doors, tires
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3a' />
 
 :::tip
 

--- a/docs/scripting/callbacks/OnVehicleSirenStateChange.md
+++ b/docs/scripting/callbacks/OnVehicleSirenStateChange.md
@@ -5,11 +5,9 @@ description: This callback is called when a vehicle's siren is toggled.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnVehicleStreamIn.md
+++ b/docs/scripting/callbacks/OnVehicleStreamIn.md
@@ -5,11 +5,9 @@ description: Called when a vehicle is streamed to a player's client.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/callbacks/OnVehicleStreamOut.md
+++ b/docs/scripting/callbacks/OnVehicleStreamOut.md
@@ -5,11 +5,9 @@ description: This callback is called when a vehicle is streamed out for a player
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='callback' version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/AddCharModel.md
+++ b/docs/scripting/functions/AddCharModel.md
@@ -5,11 +5,9 @@ description: Adds a new custom character model for download.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.DL R1 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.DL R1' />
 
 ## Description
 

--- a/docs/scripting/functions/AddSimpleModel.md
+++ b/docs/scripting/functions/AddSimpleModel.md
@@ -5,11 +5,9 @@ description: Adds a new custom simple object model for download.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.DL R1 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.DL R1' />
 
 ## Description
 

--- a/docs/scripting/functions/AddSimpleModelTimed.md
+++ b/docs/scripting/functions/AddSimpleModelTimed.md
@@ -5,11 +5,9 @@ description: Adds a new custom simple object model for download.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.DL R1 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.DL R1' />
 
 ## Description
 

--- a/docs/scripting/functions/ApplyActorAnimation.md
+++ b/docs/scripting/functions/ApplyActorAnimation.md
@@ -5,11 +5,9 @@ description: Apply an animation to an actor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/Attach3DTextLabelToPlayer.md
+++ b/docs/scripting/functions/Attach3DTextLabelToPlayer.md
@@ -5,11 +5,9 @@ description: Attach a 3D text label to a player.
 tags: ["player", "3dtextlabel"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/Attach3DTextLabelToVehicle.md
+++ b/docs/scripting/functions/Attach3DTextLabelToVehicle.md
@@ -5,11 +5,9 @@ description: Attaches a 3D Text Label to a specific vehicle.
 tags: ["vehicle", "3dtextlabel"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/AttachCameraToObject.md
+++ b/docs/scripting/functions/AttachCameraToObject.md
@@ -5,11 +5,9 @@ description: You can use this function to attach the player camera to objects.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/AttachCameraToPlayerObject.md
+++ b/docs/scripting/functions/AttachCameraToPlayerObject.md
@@ -5,11 +5,9 @@ description: Attaches a player's camera to a player-object.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/AttachObjectToObject.md
+++ b/docs/scripting/functions/AttachObjectToObject.md
@@ -5,11 +5,9 @@ description: You can use this function to attach objects to other objects.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3d and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3d' />
 
 ## Description
 

--- a/docs/scripting/functions/AttachObjectToVehicle.md
+++ b/docs/scripting/functions/AttachObjectToVehicle.md
@@ -5,11 +5,9 @@ description: Attach an object to a vehicle.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c' />
 
 ## Description
 

--- a/docs/scripting/functions/AttachPlayerObjectToVehicle.md
+++ b/docs/scripting/functions/AttachPlayerObjectToVehicle.md
@@ -5,11 +5,9 @@ description: Attach a player object to a vehicle.
 tags: ["player", "vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/BlockIpAddress.md
+++ b/docs/scripting/functions/BlockIpAddress.md
@@ -5,11 +5,9 @@ description: Blocks an IP address from further communication with the server for
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z R2-2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z R2-2' />
 
 ## Description
 

--- a/docs/scripting/functions/CancelEdit.md
+++ b/docs/scripting/functions/CancelEdit.md
@@ -5,11 +5,9 @@ description: Cancel object edition mode for a player.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/CancelSelectTextDraw.md
+++ b/docs/scripting/functions/CancelSelectTextDraw.md
@@ -5,11 +5,9 @@ description: Cancel textdraw selection with the mouse.
 tags: ["textdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/ClearActorAnimations.md
+++ b/docs/scripting/functions/ClearActorAnimations.md
@@ -5,11 +5,9 @@ description: Clear any animations applied to an actor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/ConnectNPC.md
+++ b/docs/scripting/functions/ConnectNPC.md
@@ -5,11 +5,9 @@ description: Connect an NPC to the server.
 tags: ["npc"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/Create3DTextLabel.md
+++ b/docs/scripting/functions/Create3DTextLabel.md
@@ -5,11 +5,9 @@ description: Creates a 3D Text Label at a specific location in the world.
 tags: ["3dtextlabel"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/CreateActor.md
+++ b/docs/scripting/functions/CreateActor.md
@@ -5,11 +5,9 @@ description: Create a static 'actor' in the world.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/CreateExplosionForPlayer.md
+++ b/docs/scripting/functions/CreateExplosionForPlayer.md
@@ -5,11 +5,9 @@ description: Creates an explosion that is only visible to a single player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z R2-2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z R2-2' />
 
 ## Description
 

--- a/docs/scripting/functions/CreatePlayer3DTextLabel.md
+++ b/docs/scripting/functions/CreatePlayer3DTextLabel.md
@@ -5,11 +5,9 @@ description: Creates a 3D Text Label only for a specific player.
 tags: ["player", "3dtextlabel"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/CreatePlayerTextDraw.md
+++ b/docs/scripting/functions/CreatePlayerTextDraw.md
@@ -5,11 +5,9 @@ description: Creates a textdraw for a single player.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/Delete3DTextLabel.md
+++ b/docs/scripting/functions/Delete3DTextLabel.md
@@ -5,11 +5,9 @@ description: Delete a 3D text label (created with Create3DTextLabel).
 tags: ["3dtextlabel"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/DeletePlayer3DTextLabel.md
+++ b/docs/scripting/functions/DeletePlayer3DTextLabel.md
@@ -5,11 +5,9 @@ description: Destroy a 3D text label that was created using CreatePlayer3DTextLa
 tags: ["player", "3dtextlabel"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/DestroyActor.md
+++ b/docs/scripting/functions/DestroyActor.md
@@ -5,11 +5,9 @@ description: Destroy an actor which was created with CreateActor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/DisableNameTagLOS.md
+++ b/docs/scripting/functions/DisableNameTagLOS.md
@@ -5,11 +5,9 @@ description: Disables the nametag Line-Of-Sight checking so that players can see
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/DisableRemoteVehicleCollisions.md
+++ b/docs/scripting/functions/DisableRemoteVehicleCollisions.md
@@ -5,11 +5,9 @@ description: Disables collisions between occupied vehicles for a player.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/EditAttachedObject.md
+++ b/docs/scripting/functions/EditAttachedObject.md
@@ -5,11 +5,9 @@ description: Enter edition mode for an attached object.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/EditObject.md
+++ b/docs/scripting/functions/EditObject.md
@@ -5,11 +5,9 @@ description: Allows a player to edit an object (position and rotation) using the
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/EditPlayerObject.md
+++ b/docs/scripting/functions/EditPlayerObject.md
@@ -5,11 +5,9 @@ description: Allows players to edit a player-object (position and rotation) with
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/EnablePlayerCameraTarget.md
+++ b/docs/scripting/functions/EnablePlayerCameraTarget.md
@@ -5,11 +5,9 @@ description: Toggle camera targeting functions for a player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/EnableVehicleFriendlyFire.md
+++ b/docs/scripting/functions/EnableVehicleFriendlyFire.md
@@ -5,11 +5,9 @@ description: Enable friendly fire for team vehicles.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3x and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3x' />
 
 ## Description
 

--- a/docs/scripting/functions/FindModelFileNameFromCRC.md
+++ b/docs/scripting/functions/FindModelFileNameFromCRC.md
@@ -5,11 +5,9 @@ description: Find an existing custom skin or simple object model file.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.DL R1 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.DL R1' />
 
 ## Description
 

--- a/docs/scripting/functions/FindTextureFileNameFromCRC.md
+++ b/docs/scripting/functions/FindTextureFileNameFromCRC.md
@@ -5,11 +5,9 @@ description: Find an existing custom skin or simple object texture file.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.DL R1 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.DL R1' />
 
 ## Description
 

--- a/docs/scripting/functions/GetActorFacingAngle.md
+++ b/docs/scripting/functions/GetActorFacingAngle.md
@@ -5,11 +5,9 @@ description: Get the facing angle of an actor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetActorHealth.md
+++ b/docs/scripting/functions/GetActorHealth.md
@@ -5,11 +5,9 @@ description: Get the health of an actor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetActorPoolSize.md
+++ b/docs/scripting/functions/GetActorPoolSize.md
@@ -5,11 +5,9 @@ description: Gets the highest actorid created on the server.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetActorPos.md
+++ b/docs/scripting/functions/GetActorPos.md
@@ -5,11 +5,9 @@ description: Get the position of an actor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetActorVirtualWorld.md
+++ b/docs/scripting/functions/GetActorVirtualWorld.md
@@ -5,11 +5,9 @@ description: Get the virtual world of an actor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetAnimationName.md
+++ b/docs/scripting/functions/GetAnimationName.md
@@ -5,11 +5,9 @@ description: Get the animation library/name for the index.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3b and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3b' />
 
 ## Description
 

--- a/docs/scripting/functions/GetNetworkStats.md
+++ b/docs/scripting/functions/GetNetworkStats.md
@@ -5,11 +5,9 @@ description: Gets the server's network stats and stores them in a string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c R4 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c R4' />
 
 ## Description
 

--- a/docs/scripting/functions/GetObjectModel.md
+++ b/docs/scripting/functions/GetObjectModel.md
@@ -5,11 +5,9 @@ description: Get the model ID of an object (CreateObject).
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerAnimationIndex.md
+++ b/docs/scripting/functions/GetPlayerAnimationIndex.md
@@ -5,11 +5,9 @@ description: Returns the index of any running applied animations.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3b and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3b' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCameraAspectRatio.md
+++ b/docs/scripting/functions/GetPlayerCameraAspectRatio.md
@@ -5,11 +5,9 @@ description: Retrieves the aspect ratio of a player's camera.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCameraFrontVector.md
+++ b/docs/scripting/functions/GetPlayerCameraFrontVector.md
@@ -5,11 +5,9 @@ description: This function will return the current direction of player's aiming 
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCameraMode.md
+++ b/docs/scripting/functions/GetPlayerCameraMode.md
@@ -5,11 +5,9 @@ description: Returns the current GTA camera mode for the requested player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c R3 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c R3' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCameraPos.md
+++ b/docs/scripting/functions/GetPlayerCameraPos.md
@@ -5,11 +5,9 @@ description: Get the position of the player's camera.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCameraTargetActor.md
+++ b/docs/scripting/functions/GetPlayerCameraTargetActor.md
@@ -5,11 +5,9 @@ description: Allows you to retrieve the ID of the actor the player is looking at
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCameraTargetObject.md
+++ b/docs/scripting/functions/GetPlayerCameraTargetObject.md
@@ -5,11 +5,9 @@ description: Allows you to retrieve the ID of the object the player is looking a
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCameraTargetPlayer.md
+++ b/docs/scripting/functions/GetPlayerCameraTargetPlayer.md
@@ -5,11 +5,9 @@ description: Allows you to retrieve the ID of the player the playerid is looking
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCameraTargetVehicle.md
+++ b/docs/scripting/functions/GetPlayerCameraTargetVehicle.md
@@ -5,11 +5,9 @@ description: Get the ID of the vehicle the player is looking at.
 tags: ["player", "vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCameraUpVector.md
+++ b/docs/scripting/functions/GetPlayerCameraUpVector.md
@@ -5,11 +5,9 @@ description: This function returns the vector, that points to the upside of the 
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCameraZoom.md
+++ b/docs/scripting/functions/GetPlayerCameraZoom.md
@@ -5,11 +5,9 @@ description: Retrieves the game camera zoom level for a given player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerCustomSkin.md
+++ b/docs/scripting/functions/GetPlayerCustomSkin.md
@@ -5,11 +5,9 @@ description: Returns the class of the players custom skin downloaded from the se
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.DL R1 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.DL R1' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerDistanceFromPoint.md
+++ b/docs/scripting/functions/GetPlayerDistanceFromPoint.md
@@ -5,11 +5,9 @@ description: Calculate the distance between a player and a map coordinate.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c R3 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c R3' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerDrunkLevel.md
+++ b/docs/scripting/functions/GetPlayerDrunkLevel.md
@@ -5,11 +5,9 @@ description: Checks the player's level of drunkenness.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerFightingStyle.md
+++ b/docs/scripting/functions/GetPlayerFightingStyle.md
@@ -5,11 +5,9 @@ description: Get the fighting style the player currently using.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerLastShotVectors.md
+++ b/docs/scripting/functions/GetPlayerLastShotVectors.md
@@ -5,11 +5,9 @@ description: Retrieves the start and end (hit) position of the last bullet a pla
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerNetworkStats.md
+++ b/docs/scripting/functions/GetPlayerNetworkStats.md
@@ -5,11 +5,9 @@ description: Gets a player's network stats and saves them into a string.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c R4 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c R4' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerObjectModel.md
+++ b/docs/scripting/functions/GetPlayerObjectModel.md
@@ -5,11 +5,9 @@ description: Retrieve the model ID of a player-object.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerPoolSize.md
+++ b/docs/scripting/functions/GetPlayerPoolSize.md
@@ -5,11 +5,9 @@ description: Gets the highest playerid currently in use on the server.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerSurfingObjectID.md
+++ b/docs/scripting/functions/GetPlayerSurfingObjectID.md
@@ -5,11 +5,9 @@ description: Returns the ID of the object the player is surfing on.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c R3 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c R3' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerSurfingVehicleID.md
+++ b/docs/scripting/functions/GetPlayerSurfingVehicleID.md
@@ -5,11 +5,9 @@ description: Get the ID of the vehicle that the player is surfing (stuck to the 
 tags: ["player", "vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerTargetActor.md
+++ b/docs/scripting/functions/GetPlayerTargetActor.md
@@ -5,11 +5,9 @@ description: Gets id of an actor which is aimed by certain player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerTargetPlayer.md
+++ b/docs/scripting/functions/GetPlayerTargetPlayer.md
@@ -5,11 +5,9 @@ description: Check who a player is aiming at.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3d and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3d' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerVehicleSeat.md
+++ b/docs/scripting/functions/GetPlayerVehicleSeat.md
@@ -5,11 +5,9 @@ description: Find out which seat a player is in.
 tags: ["player", "vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerVelocity.md
+++ b/docs/scripting/functions/GetPlayerVelocity.md
@@ -5,11 +5,9 @@ description: Get the velocity (speed) of a player on the X, Y and Z axes.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerVersion.md
+++ b/docs/scripting/functions/GetPlayerVersion.md
@@ -5,11 +5,9 @@ description: Returns the SA-MP client version, as reported by the player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/GetPlayerWeaponState.md
+++ b/docs/scripting/functions/GetPlayerWeaponState.md
@@ -5,11 +5,9 @@ description: Check the state of a player's weapon.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetSVarFloat.md
+++ b/docs/scripting/functions/GetSVarFloat.md
@@ -5,11 +5,9 @@ description: Gets a float server variable's value.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 R2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7 R2' />
 
 ## Description
 

--- a/docs/scripting/functions/GetSVarInt.md
+++ b/docs/scripting/functions/GetSVarInt.md
@@ -5,11 +5,9 @@ description: Gets an integer server variable's value.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 R2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7 R2' />
 
 ## Description
 

--- a/docs/scripting/functions/GetSVarString.md
+++ b/docs/scripting/functions/GetSVarString.md
@@ -5,11 +5,9 @@ description: Gets a string server variable's value.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 R2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7 R2' />
 
 ## Description
 

--- a/docs/scripting/functions/GetServerTickRate.md
+++ b/docs/scripting/functions/GetServerTickRate.md
@@ -5,11 +5,9 @@ description: Gets the tick rate (like FPS) of the server.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehicleComponentInSlot.md
+++ b/docs/scripting/functions/GetVehicleComponentInSlot.md
@@ -5,11 +5,9 @@ description: Retrieves the installed component ID (modshop mod(ification)) on a 
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehicleComponentType.md
+++ b/docs/scripting/functions/GetVehicleComponentType.md
@@ -5,11 +5,9 @@ description: Find out what type of component a certain ID is.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehicleDamageStatus.md
+++ b/docs/scripting/functions/GetVehicleDamageStatus.md
@@ -5,11 +5,9 @@ description: Retrieve the damage statuses of a vehicle.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This callback was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 :::tip
 

--- a/docs/scripting/functions/GetVehicleDistanceFromPoint.md
+++ b/docs/scripting/functions/GetVehicleDistanceFromPoint.md
@@ -5,11 +5,9 @@ description: This function can be used to calculate the distance (as a float) be
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c R3 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c R3' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehicleModelInfo.md
+++ b/docs/scripting/functions/GetVehicleModelInfo.md
@@ -5,11 +5,9 @@ description: Retrieve information about a specific vehicle model such as the siz
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehicleParamsCarDoors.md
+++ b/docs/scripting/functions/GetVehicleParamsCarDoors.md
@@ -5,11 +5,9 @@ description: Allows you to retrieve the current state of a vehicle's doors.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehicleParamsCarWindows.md
+++ b/docs/scripting/functions/GetVehicleParamsCarWindows.md
@@ -5,11 +5,9 @@ description: Allows you to retrieve the current state of a vehicle's windows.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehicleParamsEx.md
+++ b/docs/scripting/functions/GetVehicleParamsEx.md
@@ -5,11 +5,9 @@ description: Gets a vehicle's parameters.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehicleParamsSirenState.md
+++ b/docs/scripting/functions/GetVehicleParamsSirenState.md
@@ -5,11 +5,9 @@ description: Returns a vehicle's siren state (on/off).
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehiclePoolSize.md
+++ b/docs/scripting/functions/GetVehiclePoolSize.md
@@ -5,11 +5,9 @@ description: Gets the highest vehicleid currently in use on the server.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehicleRotationQuat.md
+++ b/docs/scripting/functions/GetVehicleRotationQuat.md
@@ -5,11 +5,9 @@ description: Returns a vehicle's rotation on all axes as a quaternion.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3b and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3b' />
 
 ## Description
 

--- a/docs/scripting/functions/GetVehicleVelocity.md
+++ b/docs/scripting/functions/GetVehicleVelocity.md
@@ -5,11 +5,9 @@ description: Get the velocity of a vehicle on the X, Y and Z axes.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/HTTP.md
+++ b/docs/scripting/functions/HTTP.md
@@ -5,11 +5,9 @@ description: Sends a threaded HTTP request.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3b and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3b' />
 
 ## Description
 

--- a/docs/scripting/functions/InterpolateCameraLookAt.md
+++ b/docs/scripting/functions/InterpolateCameraLookAt.md
@@ -5,11 +5,9 @@ description: Interpolate a player's camera's 'look at' point between two coordin
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/InterpolateCameraPos.md
+++ b/docs/scripting/functions/InterpolateCameraPos.md
@@ -5,11 +5,9 @@ description: Move a player's camera from one position to another, within the set
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/IsActorInvulnerable.md
+++ b/docs/scripting/functions/IsActorInvulnerable.md
@@ -5,11 +5,9 @@ description: Check if an actor is invulnerable.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/IsActorStreamedIn.md
+++ b/docs/scripting/functions/IsActorStreamedIn.md
@@ -5,11 +5,9 @@ description: Checks if an actor is streamed in for a player.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/IsObjectMoving.md
+++ b/docs/scripting/functions/IsObjectMoving.md
@@ -5,11 +5,9 @@ description: Checks if the given objectid is moving.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3d and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3d' />
 
 ## Description
 

--- a/docs/scripting/functions/IsPlayerAttachedObjectSlotUsed.md
+++ b/docs/scripting/functions/IsPlayerAttachedObjectSlotUsed.md
@@ -5,11 +5,9 @@ description: Check if a player has an object attached in the specified index (sl
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c' />
 
 ## Description
 

--- a/docs/scripting/functions/IsPlayerInRangeOfPoint.md
+++ b/docs/scripting/functions/IsPlayerInRangeOfPoint.md
@@ -5,11 +5,9 @@ description: Checks if a player is in range of a point.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/IsPlayerNPC.md
+++ b/docs/scripting/functions/IsPlayerNPC.md
@@ -5,11 +5,9 @@ description: Check if a player is an actual player or an NPC.
 tags: ["player", "npc"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/IsPlayerObjectMoving.md
+++ b/docs/scripting/functions/IsPlayerObjectMoving.md
@@ -5,11 +5,9 @@ description: Checks if the given player objectid is moving.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3d and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3d' />
 
 ## Description
 

--- a/docs/scripting/functions/IsPlayerStreamedIn.md
+++ b/docs/scripting/functions/IsPlayerStreamedIn.md
@@ -5,11 +5,9 @@ description: Checks if a player is streamed in another player's client.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/IsValidActor.md
+++ b/docs/scripting/functions/IsValidActor.md
@@ -5,11 +5,9 @@ description: Checks if an actor ID is valid.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/IsVehicleStreamedIn.md
+++ b/docs/scripting/functions/IsVehicleStreamedIn.md
@@ -5,11 +5,9 @@ description: Checks if a vehicle is streamed in for a player.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/LimitPlayerMarkerRadius.md
+++ b/docs/scripting/functions/LimitPlayerMarkerRadius.md
@@ -5,11 +5,9 @@ description: Set the player marker radius.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This Function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/ManualVehicleEngineAndLights.md
+++ b/docs/scripting/functions/ManualVehicleEngineAndLights.md
@@ -5,11 +5,9 @@ description: Use this function before any player connects (OnGameModeInit) to te
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This Function was added in SA-MP 0.3c and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c' />
 
 ## Description
 

--- a/docs/scripting/functions/NetStats_BytesReceived.md
+++ b/docs/scripting/functions/NetStats_BytesReceived.md
@@ -5,11 +5,9 @@ description: Gets the amount of data (in bytes) that the server has received fro
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/NetStats_BytesSent.md
+++ b/docs/scripting/functions/NetStats_BytesSent.md
@@ -5,11 +5,9 @@ description: Gets the amount of data (in bytes) that the server has sent to the 
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/NetStats_ConnectionStatus.md
+++ b/docs/scripting/functions/NetStats_ConnectionStatus.md
@@ -5,11 +5,9 @@ description: Gets the player's current connection status.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/NetStats_GetConnectedTime.md
+++ b/docs/scripting/functions/NetStats_GetConnectedTime.md
@@ -5,11 +5,9 @@ description: Gets the amount of time (in milliseconds) that a player has been co
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/NetStats_GetIpPort.md
+++ b/docs/scripting/functions/NetStats_GetIpPort.md
@@ -5,11 +5,9 @@ description: Get a player's IP and port.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/NetStats_MessagesReceived.md
+++ b/docs/scripting/functions/NetStats_MessagesReceived.md
@@ -5,11 +5,9 @@ description: Gets the number of messages the server has received from the player
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/NetStats_MessagesRecvPerSecond.md
+++ b/docs/scripting/functions/NetStats_MessagesRecvPerSecond.md
@@ -5,11 +5,9 @@ description: Gets the number of messages the player has received in the last sec
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/NetStats_MessagesSent.md
+++ b/docs/scripting/functions/NetStats_MessagesSent.md
@@ -5,11 +5,9 @@ description: Gets the number of messages the server has sent to the player.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/NetStats_PacketLossPercent.md
+++ b/docs/scripting/functions/NetStats_PacketLossPercent.md
@@ -5,11 +5,9 @@ description: Gets the packet loss percentage of a player.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayAudioStreamForPlayer.md
+++ b/docs/scripting/functions/PlayAudioStreamForPlayer.md
@@ -5,11 +5,9 @@ description: Play an 'audio stream' for a player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3d and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3d' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayCrimeReportForPlayer.md
+++ b/docs/scripting/functions/PlayCrimeReportForPlayer.md
@@ -5,11 +5,9 @@ description: This function plays a crime report for a player - just like in sing
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawAlignment.md
+++ b/docs/scripting/functions/PlayerTextDrawAlignment.md
@@ -5,11 +5,9 @@ description: Set the text alignment of a player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawBackgroundColor.md
+++ b/docs/scripting/functions/PlayerTextDrawBackgroundColor.md
@@ -5,11 +5,9 @@ description: Adjust the background color of a player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawBoxColor.md
+++ b/docs/scripting/functions/PlayerTextDrawBoxColor.md
@@ -5,11 +5,9 @@ description: Sets the color of a textdraw's box (PlayerTextDrawUseBox ).
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawColor.md
+++ b/docs/scripting/functions/PlayerTextDrawColor.md
@@ -5,11 +5,9 @@ description: Sets the text color of a player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawDestroy.md
+++ b/docs/scripting/functions/PlayerTextDrawDestroy.md
@@ -5,11 +5,9 @@ description: Destroy a player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawFont.md
+++ b/docs/scripting/functions/PlayerTextDrawFont.md
@@ -5,11 +5,9 @@ description: Change the font of a player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawHide.md
+++ b/docs/scripting/functions/PlayerTextDrawHide.md
@@ -5,11 +5,9 @@ description: Hide a player-textdraw from the player it was created for.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawLetterSize.md
+++ b/docs/scripting/functions/PlayerTextDrawLetterSize.md
@@ -5,11 +5,9 @@ description: Sets the width and height of the letters in a player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawSetOutline.md
+++ b/docs/scripting/functions/PlayerTextDrawSetOutline.md
@@ -5,11 +5,9 @@ description: Set the outline of a player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawSetPreviewModel.md
+++ b/docs/scripting/functions/PlayerTextDrawSetPreviewModel.md
@@ -5,11 +5,9 @@ description: Sets a player textdraw 2D preview sprite of a specified model ID.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3x and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3x' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawSetPreviewRot.md
+++ b/docs/scripting/functions/PlayerTextDrawSetPreviewRot.md
@@ -5,11 +5,9 @@ description: Sets the rotation and zoom of a 3D model preview player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3x and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3x' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawSetPreviewVehCol.md
+++ b/docs/scripting/functions/PlayerTextDrawSetPreviewVehCol.md
@@ -5,11 +5,9 @@ description: Set the color of a vehicle in a player-textdraw model preview (if a
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3x and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3x' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawSetProportional.md
+++ b/docs/scripting/functions/PlayerTextDrawSetProportional.md
@@ -5,11 +5,9 @@ description: Appears to scale text spacing to a proportional ratio.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawSetSelectable.md
+++ b/docs/scripting/functions/PlayerTextDrawSetSelectable.md
@@ -5,11 +5,9 @@ description: Toggles whether a player-textdraw can be selected or not.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawSetShadow.md
+++ b/docs/scripting/functions/PlayerTextDrawSetShadow.md
@@ -5,11 +5,9 @@ description: Adds a shadow to the bottom-right side of the text in a player-text
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawSetString.md
+++ b/docs/scripting/functions/PlayerTextDrawSetString.md
@@ -5,11 +5,9 @@ description: Change the text of a player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawShow.md
+++ b/docs/scripting/functions/PlayerTextDrawShow.md
@@ -5,11 +5,9 @@ description: Show a player-textdraw to the player it was created for.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawTextSize.md
+++ b/docs/scripting/functions/PlayerTextDrawTextSize.md
@@ -5,11 +5,9 @@ description: Change the size of a player-textdraw (box if PlayerTextDrawUseBox i
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/PlayerTextDrawUseBox.md
+++ b/docs/scripting/functions/PlayerTextDrawUseBox.md
@@ -5,11 +5,9 @@ description: Toggle the box on a player-textdraw.
 tags: ["player", "textdraw", "playertextdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This feature (player-textdraws) was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature (player-textdraws)' version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/RemoveBuildingForPlayer.md
+++ b/docs/scripting/functions/RemoveBuildingForPlayer.md
@@ -5,11 +5,9 @@ description: Removes a standard San Andreas model for a single player within a s
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3d and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3d' />
 
 ## Description
 

--- a/docs/scripting/functions/RemovePlayerAttachedObject.md
+++ b/docs/scripting/functions/RemovePlayerAttachedObject.md
@@ -5,11 +5,9 @@ description: Remove an attached object from a player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c' />
 
 ## Description
 

--- a/docs/scripting/functions/RepairVehicle.md
+++ b/docs/scripting/functions/RepairVehicle.md
@@ -5,11 +5,9 @@ description: Fully repairs a vehicle, including visual damage (bumps, dents, scr
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/SHA256_PassHash.md
+++ b/docs/scripting/functions/SHA256_PassHash.md
@@ -5,11 +5,9 @@ description: Hashes a password using the SHA-256 hashing algorithm.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 R1 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7 R1' />
 
 ## Description
 

--- a/docs/scripting/functions/SelectObject.md
+++ b/docs/scripting/functions/SelectObject.md
@@ -5,11 +5,9 @@ description: Display the cursor and allow the player to select an object.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/SelectTextDraw.md
+++ b/docs/scripting/functions/SelectTextDraw.md
@@ -5,11 +5,9 @@ description: Display the cursor and allow the player to select a textdraw.
 tags: ["textdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/SendDeathMessageToPlayer.md
+++ b/docs/scripting/functions/SendDeathMessageToPlayer.md
@@ -5,11 +5,9 @@ description: Adds a death to the 'killfeed' on the right-hand side of the screen
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This Function was added in SA-MP 0.3z R2-2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z R2-2' />
 
 ## Description
 

--- a/docs/scripting/functions/SetActorFacingAngle.md
+++ b/docs/scripting/functions/SetActorFacingAngle.md
@@ -5,11 +5,9 @@ description: Set the facing angle of an actor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/SetActorHealth.md
+++ b/docs/scripting/functions/SetActorHealth.md
@@ -5,11 +5,9 @@ description: Set the health of an actor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/SetActorInvulnerable.md
+++ b/docs/scripting/functions/SetActorInvulnerable.md
@@ -5,11 +5,9 @@ description: Toggle an actor's invulnerability.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/SetActorPos.md
+++ b/docs/scripting/functions/SetActorPos.md
@@ -5,11 +5,9 @@ description: Set the position of an actor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/SetActorVirtualWorld.md
+++ b/docs/scripting/functions/SetActorVirtualWorld.md
@@ -5,11 +5,9 @@ description: Set the virtual world of an actor.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/SetObjectMaterial.md
+++ b/docs/scripting/functions/SetObjectMaterial.md
@@ -5,11 +5,9 @@ description: Replace the texture of an object with the texture from another mode
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/SetObjectMaterialText.md
+++ b/docs/scripting/functions/SetObjectMaterialText.md
@@ -5,11 +5,9 @@ description: Replace the texture of an object with text.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/SetObjectNoCameraCol.md
+++ b/docs/scripting/functions/SetObjectNoCameraCol.md
@@ -5,11 +5,9 @@ description: Disable collisions between players' cameras and the specified objec
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/SetObjectsDefaultCameraCol.md
+++ b/docs/scripting/functions/SetObjectsDefaultCameraCol.md
@@ -5,11 +5,9 @@ description: Allows camera collisions with newly created objects to be disabled 
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerArmedWeapon.md
+++ b/docs/scripting/functions/SetPlayerArmedWeapon.md
@@ -5,11 +5,9 @@ description: Sets which weapon (that a player already has) the player is holding
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerAttachedObject.md
+++ b/docs/scripting/functions/SetPlayerAttachedObject.md
@@ -5,11 +5,9 @@ description: Attach an object to a specific bone on a player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerChatBubble.md
+++ b/docs/scripting/functions/SetPlayerChatBubble.md
@@ -5,11 +5,9 @@ description: Creates a chat bubble above a player's name tag.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerDrunkLevel.md
+++ b/docs/scripting/functions/SetPlayerDrunkLevel.md
@@ -5,11 +5,9 @@ description: Sets the drunk level of a player which makes the player's camera sw
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerFightingStyle.md
+++ b/docs/scripting/functions/SetPlayerFightingStyle.md
@@ -5,11 +5,9 @@ description: Set a player's special fighting style.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerHoldingObject.md
+++ b/docs/scripting/functions/SetPlayerHoldingObject.md
@@ -5,11 +5,9 @@ description: Attaches an object to a bone.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3b and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3b' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerObjectMaterial.md
+++ b/docs/scripting/functions/SetPlayerObjectMaterial.md
@@ -5,11 +5,9 @@ description: Replace the texture of a player-object with the texture from anothe
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerObjectMaterialText.md
+++ b/docs/scripting/functions/SetPlayerObjectMaterialText.md
@@ -5,11 +5,9 @@ description: Replace the texture of a player object with text.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerObjectNoCameraCol.md
+++ b/docs/scripting/functions/SetPlayerObjectNoCameraCol.md
@@ -5,11 +5,9 @@ description: Toggles a player object camera collision.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerShopName.md
+++ b/docs/scripting/functions/SetPlayerShopName.md
@@ -5,11 +5,9 @@ description: Loads or unloads an interior script for a player (for example the a
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerSkillLevel.md
+++ b/docs/scripting/functions/SetPlayerSkillLevel.md
@@ -5,11 +5,9 @@ description: Set the skill level of a certain weapon type for a player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/SetPlayerVelocity.md
+++ b/docs/scripting/functions/SetPlayerVelocity.md
@@ -5,11 +5,9 @@ description: Set a player's velocity on the X, Y and Z axes.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/SetSVarFloat.md
+++ b/docs/scripting/functions/SetSVarFloat.md
@@ -5,11 +5,9 @@ description: Set a float server variable.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 R2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7 R2' />
 
 ## Description
 

--- a/docs/scripting/functions/SetSVarInt.md
+++ b/docs/scripting/functions/SetSVarInt.md
@@ -5,11 +5,9 @@ description: Set an integer server variable.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 R2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7 R2' />
 
 ## Description
 

--- a/docs/scripting/functions/SetSVarString.md
+++ b/docs/scripting/functions/SetSVarString.md
@@ -5,11 +5,9 @@ description: Set a string server variable.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 R2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7 R2' />
 
 ## Description
 

--- a/docs/scripting/functions/SetVehicleAngularVelocity.md
+++ b/docs/scripting/functions/SetVehicleAngularVelocity.md
@@ -5,11 +5,9 @@ description: Sets the angular X, Y and Z velocity of a vehicle.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3b and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3b' />
 
 :::info
 

--- a/docs/scripting/functions/SetVehicleNumberPlate.md
+++ b/docs/scripting/functions/SetVehicleNumberPlate.md
@@ -5,11 +5,9 @@ description: Set a vehicle numberplate.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c' />
 
 ## Description
 

--- a/docs/scripting/functions/SetVehicleParamsCarDoors.md
+++ b/docs/scripting/functions/SetVehicleParamsCarDoors.md
@@ -5,11 +5,9 @@ description: Allows you to open and close the doors of a vehicle.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/SetVehicleParamsCarWindows.md
+++ b/docs/scripting/functions/SetVehicleParamsCarWindows.md
@@ -5,11 +5,9 @@ description: Allows you to open and close the windows of a vehicle.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3.7 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3.7' />
 
 ## Description
 

--- a/docs/scripting/functions/SetVehicleParamsEx.md
+++ b/docs/scripting/functions/SetVehicleParamsEx.md
@@ -5,11 +5,9 @@ description: Sets a vehicle's parameters for all players.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3c and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3c' />
 
 ## Description
 

--- a/docs/scripting/functions/SetVehicleVelocity.md
+++ b/docs/scripting/functions/SetVehicleVelocity.md
@@ -5,11 +5,9 @@ description: Sets the X, Y and Z velocity of a vehicle.
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/ShowPlayerDialog.md
+++ b/docs/scripting/functions/ShowPlayerDialog.md
@@ -5,11 +5,9 @@ description: Shows the player a synchronous (only one at a time) dialog box.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/StartRecordingPlayerData.md
+++ b/docs/scripting/functions/StartRecordingPlayerData.md
@@ -5,11 +5,9 @@ description: Starts recording a player's movements to a file, which can then be 
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/StopAudioStreamForPlayer.md
+++ b/docs/scripting/functions/StopAudioStreamForPlayer.md
@@ -5,11 +5,9 @@ description: Stops the current audio stream for a player.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3d and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3d' />
 
 ## Description
 

--- a/docs/scripting/functions/StopPlayerHoldingObject.md
+++ b/docs/scripting/functions/StopPlayerHoldingObject.md
@@ -5,11 +5,9 @@ description: Removes attached objects.
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3b and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3b' />
 
 ## Description
 

--- a/docs/scripting/functions/StopRecordingPlayerData.md
+++ b/docs/scripting/functions/StopRecordingPlayerData.md
@@ -5,11 +5,9 @@ description: Stops all the recordings that had been started with StartRecordingP
 tags: ["player"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/TextDrawSetPreviewModel.md
+++ b/docs/scripting/functions/TextDrawSetPreviewModel.md
@@ -5,11 +5,9 @@ description: Set the model for a textdraw model preview.
 tags: ["textdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3x and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3x' />
 
 ## Description
 

--- a/docs/scripting/functions/TextDrawSetPreviewRot.md
+++ b/docs/scripting/functions/TextDrawSetPreviewRot.md
@@ -5,11 +5,9 @@ description: Sets the rotation and zoom of a 3D model preview textdraw.
 tags: ["textdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3x and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3x' />
 
 ## Description
 

--- a/docs/scripting/functions/TextDrawSetPreviewVehCol.md
+++ b/docs/scripting/functions/TextDrawSetPreviewVehCol.md
@@ -5,11 +5,9 @@ description: If a vehicle model is used in a 3D preview textdraw, this sets the 
 tags: ["textdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3x and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3x' />
 
 ## Description
 

--- a/docs/scripting/functions/TextDrawSetSelectable.md
+++ b/docs/scripting/functions/TextDrawSetSelectable.md
@@ -5,11 +5,9 @@ description: Sets whether a textdraw can be selected (clicked on) or not.
 tags: ["textdraw"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3e and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3e' />
 
 ## Description
 

--- a/docs/scripting/functions/Tickcount.md
+++ b/docs/scripting/functions/Tickcount.md
@@ -4,11 +4,9 @@ description: This function can be used as a replacement for GetTickCount, as it 
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/UnBlockIpAddress.md
+++ b/docs/scripting/functions/UnBlockIpAddress.md
@@ -5,11 +5,9 @@ description: Unblock an IP address that was previously blocked using BlockIpAddr
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z R2-2 and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z R2-2' />
 
 ## Description
 

--- a/docs/scripting/functions/Update3DTextLabelText.md
+++ b/docs/scripting/functions/Update3DTextLabelText.md
@@ -5,11 +5,9 @@ description: Updates a 3D Text Label text and color.
 tags: ["3dtextlabel"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/UpdatePlayer3DTextLabelText.md
+++ b/docs/scripting/functions/UpdatePlayer3DTextLabelText.md
@@ -5,11 +5,9 @@ description: Updates a player 3D Text Label's text and color.
 tags: ["player", "3dtextlabel"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 ## Description
 

--- a/docs/scripting/functions/UpdateVehicleDamageStatus.md
+++ b/docs/scripting/functions/UpdateVehicleDamageStatus.md
@@ -5,11 +5,9 @@ description: Sets the various visual damage statuses of a vehicle, such as poppe
 tags: ["vehicle"]
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3a and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3a' />
 
 :::tip
 

--- a/docs/scripting/functions/VectorSize.md
+++ b/docs/scripting/functions/VectorSize.md
@@ -5,11 +5,9 @@ description: Returns the norm (length) of the provided vector.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn version='SA-MP 0.3z' />
 
 ## Description
 

--- a/docs/scripting/functions/acos.md
+++ b/docs/scripting/functions/acos.md
@@ -5,11 +5,9 @@ description: .
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/asin.md
+++ b/docs/scripting/functions/asin.md
@@ -5,11 +5,9 @@ description: .
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/atan.md
+++ b/docs/scripting/functions/atan.md
@@ -5,11 +5,9 @@ description: Get the inversed value of an arc tangent in radians.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/atan2.md
+++ b/docs/scripting/functions/atan2.md
@@ -5,11 +5,9 @@ description: .
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 :::warning
 

--- a/docs/scripting/functions/clamp.md
+++ b/docs/scripting/functions/clamp.md
@@ -5,11 +5,9 @@ description: Force a value to be inside a range.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_close.md
+++ b/docs/scripting/functions/db_close.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_debug_openfiles.md
+++ b/docs/scripting/functions/db_debug_openfiles.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_debug_openresults.md
+++ b/docs/scripting/functions/db_debug_openresults.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_field_name.md
+++ b/docs/scripting/functions/db_field_name.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_free_result.md
+++ b/docs/scripting/functions/db_free_result.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_get_field.md
+++ b/docs/scripting/functions/db_get_field.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_get_field_assoc.md
+++ b/docs/scripting/functions/db_get_field_assoc.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_get_field_assoc_float.md
+++ b/docs/scripting/functions/db_get_field_assoc_float.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_get_field_assoc_int.md
+++ b/docs/scripting/functions/db_get_field_assoc_int.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_get_field_float.md
+++ b/docs/scripting/functions/db_get_field_float.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_get_field_int.md
+++ b/docs/scripting/functions/db_get_field_int.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_get_mem_handle.md
+++ b/docs/scripting/functions/db_get_mem_handle.md
@@ -10,7 +10,7 @@ import T from '../../../src/components/templates.js'
 
 <T.LowercaseNote />
 
-<T.VersionWarn name='function' version='SA-MP 0.3.7 R1' />
+<T.VersionWarn version='SA-MP 0.3.7 R1' />
 
 ## Description
 

--- a/docs/scripting/functions/db_get_mem_handle.md
+++ b/docs/scripting/functions/db_get_mem_handle.md
@@ -6,7 +6,6 @@ keywords:
   - sqlite
 ---
 
-
 import T from '../../../src/components/templates.js'
 
 <T.LowercaseNote />

--- a/docs/scripting/functions/db_get_mem_handle.md
+++ b/docs/scripting/functions/db_get_mem_handle.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter. 
-
-:::
+<T.LowercaseNote />
 
 import T from '../../../src/components/templates.js'
 

--- a/docs/scripting/functions/db_get_mem_handle.md
+++ b/docs/scripting/functions/db_get_mem_handle.md
@@ -8,9 +8,13 @@ keywords:
 
 :::warning
 
-The function starts with a lowercase letter. The function was added in SA-MP 0.3.7 R1 and will not work in earlier versions!
+The function starts with a lowercase letter. 
 
 :::
+
+import T from '../../../src/components/templates.js'
+
+<T.VersionWarn name='function' version='SA-MP 0.3.7 R1' />
 
 ## Description
 

--- a/docs/scripting/functions/db_get_result_mem_handle.md
+++ b/docs/scripting/functions/db_get_result_mem_handle.md
@@ -10,7 +10,7 @@ import T from '../../../src/components/templates.js'
 
 <T.LowercaseNote />
 
-<T.VersionWarn name='function' version='SA-MP 0.3.7 R1' />
+<T.VersionWarn version='SA-MP 0.3.7 R1' />
 
 ## Description
 

--- a/docs/scripting/functions/db_get_result_mem_handle.md
+++ b/docs/scripting/functions/db_get_result_mem_handle.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter. 
-
-:::
+<T.LowercaseNote />
 
 import T from '../../../src/components/templates.js'
 

--- a/docs/scripting/functions/db_get_result_mem_handle.md
+++ b/docs/scripting/functions/db_get_result_mem_handle.md
@@ -8,9 +8,13 @@ keywords:
 
 :::warning
 
-The function starts with a lowercase letter. The function was added in SA-MP 0.3.7 R1 and will not work in earlier versions!
+The function starts with a lowercase letter. 
 
 :::
+
+import T from '../../../src/components/templates.js'
+
+<T.VersionWarn name='function' version='SA-MP 0.3.7 R1' />
 
 ## Description
 

--- a/docs/scripting/functions/db_next_row.md
+++ b/docs/scripting/functions/db_next_row.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_num_fields.md
+++ b/docs/scripting/functions/db_num_fields.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_num_rows.md
+++ b/docs/scripting/functions/db_num_rows.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_open.md
+++ b/docs/scripting/functions/db_open.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/db_query.md
+++ b/docs/scripting/functions/db_query.md
@@ -6,11 +6,9 @@ keywords:
   - sqlite
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-The function starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/deleteproperty.md
+++ b/docs/scripting/functions/deleteproperty.md
@@ -5,11 +5,9 @@ description: Delete an earlier set property (setproperty).
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/existproperty.md
+++ b/docs/scripting/functions/existproperty.md
@@ -5,11 +5,9 @@ description: Check if a property exist.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fblockread.md
+++ b/docs/scripting/functions/fblockread.md
@@ -5,11 +5,9 @@ description: This function allows you to read data from a file, without encoding
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fblockwrite.md
+++ b/docs/scripting/functions/fblockwrite.md
@@ -5,11 +5,9 @@ description: Write data to a file in binary format, while ignoring line brakes a
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fclose.md
+++ b/docs/scripting/functions/fclose.md
@@ -5,11 +5,9 @@ description: Closes a file.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fexist.md
+++ b/docs/scripting/functions/fexist.md
@@ -5,11 +5,9 @@ description: Checks if a specific file exists in the scriptfiles directory.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fgetchar.md
+++ b/docs/scripting/functions/fgetchar.md
@@ -5,11 +5,9 @@ description: Reads a single character from a file.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/flength.md
+++ b/docs/scripting/functions/flength.md
@@ -5,11 +5,9 @@ description: Returns the length of a file.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/float.md
+++ b/docs/scripting/functions/float.md
@@ -5,11 +5,9 @@ description: Converts an integer into a float.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatabs.md
+++ b/docs/scripting/functions/floatabs.md
@@ -5,11 +5,9 @@ description: This function returns the absolute value of float.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatadd.md
+++ b/docs/scripting/functions/floatadd.md
@@ -5,11 +5,9 @@ description: Adds two floats together.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatcmp.md
+++ b/docs/scripting/functions/floatcmp.md
@@ -5,11 +5,9 @@ description: floatcmp can be used to compare float values to each other, to vali
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatcos.md
+++ b/docs/scripting/functions/floatcos.md
@@ -5,11 +5,9 @@ description: Get the cosine from a given angle.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatdiv.md
+++ b/docs/scripting/functions/floatdiv.md
@@ -5,11 +5,9 @@ description: Divide one float by another one.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatfract.md
+++ b/docs/scripting/functions/floatfract.md
@@ -5,11 +5,9 @@ description: Get the fractional part of a float.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatlog.md
+++ b/docs/scripting/functions/floatlog.md
@@ -5,11 +5,9 @@ description: This function allows you to get the logarithm of a float value.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatmul.md
+++ b/docs/scripting/functions/floatmul.md
@@ -5,11 +5,9 @@ description: Multiplies two floats with each other.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatpower.md
+++ b/docs/scripting/functions/floatpower.md
@@ -5,11 +5,9 @@ description: Raises the given value to the power of the exponent.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatround.md
+++ b/docs/scripting/functions/floatround.md
@@ -5,11 +5,9 @@ description: Round a floating point number to an integer value.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatsin.md
+++ b/docs/scripting/functions/floatsin.md
@@ -5,11 +5,9 @@ description: Get the sine from a given angle.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatsqroot.md
+++ b/docs/scripting/functions/floatsqroot.md
@@ -5,11 +5,9 @@ description: Calculates the square root of given value.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatstr.md
+++ b/docs/scripting/functions/floatstr.md
@@ -5,11 +5,9 @@ description: Converts a string to a float.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floatsub.md
+++ b/docs/scripting/functions/floatsub.md
@@ -5,11 +5,9 @@ description: Subtracts one float from another one.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/floattan.md
+++ b/docs/scripting/functions/floattan.md
@@ -5,11 +5,9 @@ description: Get the tangent from a given angle.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fmatch.md
+++ b/docs/scripting/functions/fmatch.md
@@ -5,11 +5,9 @@ description: Find a filename matching a pattern.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fopen.md
+++ b/docs/scripting/functions/fopen.md
@@ -5,11 +5,9 @@ description: Open a file (to read from or write to).
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/format.md
+++ b/docs/scripting/functions/format.md
@@ -5,11 +5,9 @@ description: Formats a string to include variables and other strings inside it.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fputchar.md
+++ b/docs/scripting/functions/fputchar.md
@@ -5,11 +5,9 @@ description: Write one character to a file.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fread.md
+++ b/docs/scripting/functions/fread.md
@@ -5,11 +5,9 @@ description: Read a single line from a file.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fremove.md
+++ b/docs/scripting/functions/fremove.md
@@ -5,11 +5,9 @@ description: Delete a file.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fseek.md
+++ b/docs/scripting/functions/fseek.md
@@ -5,11 +5,9 @@ description: Change the current position in the file.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/ftemp.md
+++ b/docs/scripting/functions/ftemp.md
@@ -5,11 +5,9 @@ description: Creates a file in the "tmp", "temp" or root directory with random n
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/funcidx.md
+++ b/docs/scripting/functions/funcidx.md
@@ -5,11 +5,9 @@ description: This function returns the ID of a public function by its name.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/fwrite.md
+++ b/docs/scripting/functions/fwrite.md
@@ -5,11 +5,9 @@ description: Write text into a file.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/getarg.md
+++ b/docs/scripting/functions/getarg.md
@@ -5,11 +5,9 @@ description: Get an argument that was passed to a function.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/getdate.md
+++ b/docs/scripting/functions/getdate.md
@@ -5,11 +5,9 @@ description: Get the current server date, which will be stored in the variables 
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/getproperty.md
+++ b/docs/scripting/functions/getproperty.md
@@ -5,11 +5,9 @@ description: Get a specific property from the memory, the string is returned as 
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/gettime.md
+++ b/docs/scripting/functions/gettime.md
@@ -5,11 +5,9 @@ description: Get the current server time, which will be stored in the variables 
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/gpci.md
+++ b/docs/scripting/functions/gpci.md
@@ -5,11 +5,9 @@ description: Fetch the GPCI of a user, this is linked to their SAMP/GTA on their
 tags: []
 ---
 
-:::note
+import T from '../../../src/components/templates.js'
 
-This function name starts with a lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/heapspace.md
+++ b/docs/scripting/functions/heapspace.md
@@ -5,11 +5,9 @@ description: Returns the amount of memory available for the heap/stack in bytes.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/ispacked.md
+++ b/docs/scripting/functions/ispacked.md
@@ -5,11 +5,9 @@ description: Checks if the given string is packed.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/listenport.md
+++ b/docs/scripting/functions/listenport.md
@@ -5,8 +5,6 @@ description: .
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />

--- a/docs/scripting/functions/max.md
+++ b/docs/scripting/functions/max.md
@@ -5,11 +5,9 @@ description: .
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/memcpy.md
+++ b/docs/scripting/functions/memcpy.md
@@ -5,11 +5,9 @@ description: Copy bytes from one location to another.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/min.md
+++ b/docs/scripting/functions/min.md
@@ -5,11 +5,9 @@ description: .
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/numargs.md
+++ b/docs/scripting/functions/numargs.md
@@ -5,11 +5,9 @@ description: Get the number of arguments passed to a function.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/print.md
+++ b/docs/scripting/functions/print.md
@@ -5,11 +5,9 @@ description: Prints a string to the server console (not in-game chat) and logs (
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/printf.md
+++ b/docs/scripting/functions/printf.md
@@ -5,11 +5,9 @@ description: Outputs a formatted string on the console (the server window, not t
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/random.md
+++ b/docs/scripting/functions/random.md
@@ -5,11 +5,9 @@ description: Get a pseudo-random number.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/sendpacket.md
+++ b/docs/scripting/functions/sendpacket.md
@@ -5,8 +5,6 @@ description: .
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />

--- a/docs/scripting/functions/sendstring.md
+++ b/docs/scripting/functions/sendstring.md
@@ -5,8 +5,6 @@ description: .
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />

--- a/docs/scripting/functions/setarg.md
+++ b/docs/scripting/functions/setarg.md
@@ -5,11 +5,9 @@ description: Set an argument that was passed to a function.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/setproperty.md
+++ b/docs/scripting/functions/setproperty.md
@@ -5,11 +5,9 @@ description: Add a new property or change an existing property.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/strcat.md
+++ b/docs/scripting/functions/strcat.md
@@ -5,11 +5,9 @@ description: This function concatenates (joins together) two strings into the de
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/strcmp.md
+++ b/docs/scripting/functions/strcmp.md
@@ -5,11 +5,9 @@ description: Compares two strings to see if they are the same.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/strdel.md
+++ b/docs/scripting/functions/strdel.md
@@ -5,11 +5,9 @@ description: Delete part of a string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/strfind.md
+++ b/docs/scripting/functions/strfind.md
@@ -5,11 +5,9 @@ description: Search for a sub string in a string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/strins.md
+++ b/docs/scripting/functions/strins.md
@@ -5,11 +5,9 @@ description: Insert a string into another string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/strlen.md
+++ b/docs/scripting/functions/strlen.md
@@ -5,11 +5,9 @@ description: Get the length of a string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/strmid.md
+++ b/docs/scripting/functions/strmid.md
@@ -5,11 +5,9 @@ description: Extract a range of characters from a string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/strpack.md
+++ b/docs/scripting/functions/strpack.md
@@ -5,11 +5,9 @@ description: Pack a string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/strunpack.md
+++ b/docs/scripting/functions/strunpack.md
@@ -5,11 +5,9 @@ description: This function can be used to unpack a string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/strval.md
+++ b/docs/scripting/functions/strval.md
@@ -5,11 +5,9 @@ description: Convert a string to an integer.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/swapchars.md
+++ b/docs/scripting/functions/swapchars.md
@@ -5,8 +5,6 @@ description: .
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />

--- a/docs/scripting/functions/tolower.md
+++ b/docs/scripting/functions/tolower.md
@@ -5,11 +5,9 @@ description: This function changes a single character to lowercase.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/toupper.md
+++ b/docs/scripting/functions/toupper.md
@@ -5,11 +5,9 @@ description: This function changes a single character to uppercase.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/uudecode.md
+++ b/docs/scripting/functions/uudecode.md
@@ -5,11 +5,9 @@ description: Decode an UU-encoded string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/uuencode.md
+++ b/docs/scripting/functions/uuencode.md
@@ -5,11 +5,9 @@ description: Encode a string to an UU-decoded string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/functions/valstr.md
+++ b/docs/scripting/functions/valstr.md
@@ -5,11 +5,9 @@ description: Convert an integer into a string.
 tags: []
 ---
 
-:::warning
+import T from '../../../src/components/templates.js'
 
-This function starts with lowercase letter.
-
-:::
+<T.LowercaseNote />
 
 ## Description
 

--- a/docs/scripting/resources/_server/lagcompensation.md
+++ b/docs/scripting/resources/_server/lagcompensation.md
@@ -4,11 +4,9 @@ title: "Lag Compensation"
 descripion: Lag compensation explanation.
 ---
 
-:::warning
+import T from '../../../../src/components/templates.js'
 
-This feature was added in SA-MP 0.3z and will not work in earlier versions!
-
-:::
+<T.VersionWarn name='feature' version='SA-MP 0.3z' />
 
 Lag compensation for fired bullets is enabled by default on SA-MP servers since 0.3z. It can be toggled using the `lagcompmode` server variable in [server.cfg](server.cfg). Setting it to 0 will disable lag compensation completely and players will have to lead their shots (fired ahead of targets).
 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "@docusaurus/preset-classic": "^2.0.0-alpha.54",
     "classnames": "^2.2.6",
     "directory-tree": "^2.2.4",
+    "html-react-parser": "^0.14.0",
     "iso-639-1": "^2.1.4",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "remark-html": "^13.0.1"
   },
   "browserslist": {
     "production": [

--- a/src/components/templates.js
+++ b/src/components/templates.js
@@ -1,3 +1,4 @@
 import VersionWarn from "./templates/version-warning";
+import LowercaseNote from "./templates/lowercase-note";
 
-export default { VersionWarn };
+export default { VersionWarn, LowercaseNote };

--- a/src/components/templates.js
+++ b/src/components/templates.js
@@ -1,0 +1,3 @@
+import VersionWarn from './templates/version-warning';
+
+export default { VersionWarn };

--- a/src/components/templates.js
+++ b/src/components/templates.js
@@ -1,3 +1,3 @@
-import VersionWarn from './templates/version-warning';
+import VersionWarn from "./templates/version-warning";
 
 export default { VersionWarn };

--- a/src/components/templates/lowercase-note.js
+++ b/src/components/templates/lowercase-note.js
@@ -1,0 +1,16 @@
+import markdown from "remark-parse";
+import html from "remark-html";
+import admonitions from "remark-admonitions";
+import parseHtml from "html-react-parser";
+import unified from "unified";
+
+export default ({ name = 'function' }) => {
+  let result = unified()
+    .use(markdown)
+    .use(admonitions, {})
+    .use(html)
+    .processSync(
+      `:::note \n\nThis ${name} starts with a lowercase letter.\n\n:::`
+    );
+  return parseHtml(result.contents);
+};

--- a/src/components/templates/lowercase-note.js
+++ b/src/components/templates/lowercase-note.js
@@ -4,7 +4,7 @@ import admonitions from "remark-admonitions";
 import parseHtml from "html-react-parser";
 import unified from "unified";
 
-export default ({ name = 'function' }) => {
+export default ({ name = "function" }) => {
   let result = unified()
     .use(markdown)
     .use(admonitions, {})

--- a/src/components/templates/version-warning.js
+++ b/src/components/templates/version-warning.js
@@ -1,14 +1,16 @@
 import markdown from "remark-parse";
-import html from 'remark-html';
+import html from "remark-html";
 import admonitions from "remark-admonitions";
-import parseHtml from 'html-react-parser';
+import parseHtml from "html-react-parser";
 import unified from "unified";
 
 export default ({ verNum }) => {
-    let result = unified()
-        .use(markdown)
-        .use(admonitions, {})
-        .use(html)
-        .processSync(`:::warning \n\nThis function was added in SA-MP ${verNum} and will not work in earlier versions!\n\n:::`);
-    return parseHtml(result.contents);
-}
+  let result = unified()
+    .use(markdown)
+    .use(admonitions, {})
+    .use(html)
+    .processSync(
+      `:::warning \n\nThis function was added in SA-MP ${verNum} and will not work in earlier versions!\n\n:::`
+    );
+  return parseHtml(result.contents);
+};

--- a/src/components/templates/version-warning.js
+++ b/src/components/templates/version-warning.js
@@ -1,0 +1,14 @@
+import markdown from "remark-parse";
+import html from 'remark-html';
+import admonitions from "remark-admonitions";
+import parseHtml from 'html-react-parser';
+import unified from "unified";
+
+export default ({ verNum }) => {
+    let result = unified()
+        .use(markdown)
+        .use(admonitions, {})
+        .use(html)
+        .processSync(`:::warning \n\nThis function was added in SA-MP ${verNum} and will not work in earlier versions!\n\n:::`);
+    return parseHtml(result.contents);
+}

--- a/src/components/templates/version-warning.js
+++ b/src/components/templates/version-warning.js
@@ -4,13 +4,13 @@ import admonitions from "remark-admonitions";
 import parseHtml from "html-react-parser";
 import unified from "unified";
 
-export default ({ verNum }) => {
+export default ({ version, name = 'function' }) => {
   let result = unified()
     .use(markdown)
     .use(admonitions, {})
     .use(html)
     .processSync(
-      `:::warning \n\nThis function was added in SA-MP ${verNum} and will not work in earlier versions!\n\n:::`
+      `:::warning \n\nThis ${name} was added in ${version} and will not work in earlier versions!\n\n:::`
     );
   return parseHtml(result.contents);
 };


### PR DESCRIPTION
https://github.com/openmultiplayer/wiki/blob/amir/new-templates/src/components/templates/version-warning.js

What this actually does is taking markdown as an input in unifier with remark module involved, then gives HTML output and then we parse the HTML code text to an actual HTML based code/component

Also importing and exporting them all (it's just one now, but gonna be more in future of course for other admonitions that are being used) in this file called `templates.js`

https://github.com/openmultiplayer/wiki/blob/amir/new-templates/src/components/templates.js

and now we're gonna use them like this (down below) in our `.md` or `.mdx` files:

```js
import T from '../../../src/components/templates.js'

<T.VersionWarn verNum='0.3.7' />
```
wait till I add others, and replace most of current note blocks with new templates

**_Do not merge it yet_**