### PR TITLE
Add missing links to vehicle health in Get/Set functions

### DIFF
--- a/docs/scripting/functions/GetVehicleHealth.md
+++ b/docs/scripting/functions/GetVehicleHealth.md
@@ -47,7 +47,7 @@ if (strcmp(cmdtext, "/repair", true) == 0)
 
 :::tip
 
-Full vehicle health is 1000, however higher values are possible and increase the health of the vehicle. For more information on health values, see here.
+Full vehicle health is 1000, however higher values are possible and increase the health of the vehicle. For more information on health values, see [here](../resources/vehiclehealth.md).
 
 :::
 

--- a/docs/scripting/functions/SetVehicleHealth.md
+++ b/docs/scripting/functions/SetVehicleHealth.md
@@ -38,7 +38,7 @@ if (strcmp("/fixengine", cmdtext, true) == 0)
 
 :::tip
 
-Full vehicle health is 1000. Higher values are possible. For more information on health values, see this page.
+Full vehicle health is 1000. Higher values are possible. For more information on health values, see [this](../resources/vehiclehealth.md) page.
 
 :::
 


### PR DESCRIPTION
Currently there are missing links, this should link them together.